### PR TITLE
.ci-test.sh: new test file for CI

### DIFF
--- a/.ci-test.sh
+++ b/.ci-test.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Pretend like we're Travis so that scripts behave accordingly.
+export TRAVIS=true
+
+# NB: set to false if we don't want to test assets
+export TEST_ASSETS=true
+
+echo "GOPATH = $GOPATH"
+echo "PATH = $PATH"
+go version
+go env
+
+cd $GOPATH/src/github.com/projectatomic/appinfra-next
+
+# overall job status
+failed=false
+
+# run the passed command and capture output in a log
+log_eval() {
+
+	echo "RUNNING: $@" | tee -a $HOME/log
+	eval $@ &>> $HOME/log
+
+	if [ $? == 0 ]; then
+		res=PASSED
+	else
+		res=FAILED
+		failed=true
+	fi
+
+	echo "$res: $@" | tee -a $HOME/log
+}
+
+# installs
+
+log_eval ./hack/verify-jsonformat.sh
+log_eval ./hack/install-etcd.sh
+log_eval ./hack/install-std-race.sh
+log_eval ./hack/install-tools.sh
+log_eval ./hack/build-go.sh
+log_eval ./hack/install-assets.sh
+
+# tests
+
+log_eval \
+	PATH=./_output/etcd/bin:$PATH \
+		make check-test WHAT="''" TESTFLAGS="-p=4"
+
+log_eval ./hack/test-assets.sh
+
+if [ "$failed" = true ]; then
+	exit 1
+fi


### PR DESCRIPTION
This file is translated from the Travis yml file so that it can be used
in other CI systems such as Jenkins. Eventually, we should remove hacks
such as "export TRAVIS=true".
