### PR TITLE
Updated service locations

### DIFF
--- a/atomic-enterprise.spec
+++ b/atomic-enterprise.spec
@@ -8,7 +8,7 @@
 # %%commit and %%ldflags are intended to be set by tito custom builders provided
 # in the rel-eng directory. The values in this spec file will not be kept up to date.
 %{!?commit:
-%global commit e3c46fd8fabcec6088aa58566836bccee9f4fbfc
+%global commit 54e7bfc9b4765a22ddb4c9c8a0c37c42eeab0dbd
 }
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 # OpenShift AE specific ldflags from hack/common.sh os::build:ldflags
@@ -25,7 +25,7 @@ Summary:        Open Source Platform as a Service by Red Hat
 License:        ASL 2.0
 URL:            https://%{import_path}
 ExclusiveArch:  x86_64
-Source0:        atomic-enterprise-git-0.097952c.tar.gz
+Source0:        %{name}-git-0.%{shortcommit}.tar.gz
 
 BuildRequires:  systemd
 BuildRequires:  golang >= 1.4
@@ -48,7 +48,7 @@ Requires(postun): systemd
 Summary:        Atomic Enterprise Node
 Requires:       %{name} = %{version}-%{release}
 Requires:       docker >= 1.6.2
-Requires:       tuned-profiles-atomic-enterprise-node
+Requires:       tuned-profiles-%{name}-node
 Requires:       util-linux
 Requires:       socat
 Requires(post): systemd
@@ -58,12 +58,12 @@ Requires(postun): systemd
 %description node
 %{summary}
 
-%package -n tuned-profiles-atomic-enterprise-node
+%package -n tuned-profiles-%{name}-node
 Summary:        Tuned profiles for OpenShift AE Node hosts
 Requires:       tuned >= 2.3
 Requires:       %{name} = %{version}-%{release}
 
-%description -n tuned-profiles-atomic-enterprise-node
+%description -n tuned-profiles-%{name}-node
 %{summary}
 
 %package clients
@@ -99,7 +99,7 @@ Requires:         ethtool
 %{summary}
 
 %prep
-%setup -q -n atomic-enterprise-git-0.097952c
+%setup -q -n %{name}-git-0.%{shortcommit}
 
 %build
 
@@ -185,8 +185,8 @@ pushd _thirdpartyhacks/src/%{sdn_import_path}/ovssubnet/bin
    install -p -m 755 openshift-ovs-subnet %{buildroot}%{kube_plugin_path}/openshift-ovs-subnet
    install -p -m 755 openshift-sdn-kube-subnet-setup.sh %{buildroot}%{_bindir}/
 popd
-install -d -m 0755 %{buildroot}%{_prefix}/lib/systemd/system/openshift-node.service.d
-install -p -m 0644 rel-eng/openshift-sdn-ovs.conf %{buildroot}%{_prefix}/lib/systemd/system/openshift-node.service.d/
+install -d -m 0755 %{buildroot}%{_prefix}/lib/systemd/system/%{name}-node.service.d
+install -p -m 0644 rel-eng/openshift-sdn-ovs.conf %{buildroot}%{_prefix}/lib/systemd/system/%{name}-node.service.d/%{name}-sdn-ovs.conf
 install -d -m 0755 %{buildroot}%{_prefix}/lib/systemd/system/docker.service.d
 install -p -m 0644 rel-eng/docker-sdn-ovs.conf %{buildroot}%{_prefix}/lib/systemd/system/docker.service.d/
 
@@ -238,16 +238,16 @@ install -p -m 644 rel-eng/completions/bash/* %{buildroot}/etc/bash_completion.d/
 %defattr(-,root,root,-)
 %{_bindir}/openshift-sdn-kube-subnet-setup.sh
 %{kube_plugin_path}/openshift-ovs-subnet
-%{_prefix}/lib/systemd/system/openshift-node.service.d/openshift-sdn-ovs.conf
+%{_prefix}/lib/systemd/system/%{name}-node.service.d/%{name}-sdn-ovs.conf
 %{_prefix}/lib/systemd/system/docker.service.d/docker-sdn-ovs.conf
 
-%files -n tuned-profiles-atomic-enterprise-node
+%files -n tuned-profiles-%{name}-node
 %defattr(-,root,root,-)
 %{_prefix}/lib/tuned/openshift-node-host
 %{_prefix}/lib/tuned/openshift-node-guest
 %{_mandir}/man7/tuned-profiles-openshift-node.7*
 
-%post -n tuned-profiles-atomic-enterprise-node
+%post -n tuned-profiles-%{name}-node
 recommended=`/usr/sbin/tuned-adm recommend`
 if [[ "${recommended}" =~ guest ]] ; then
   /usr/sbin/tuned-adm profile openshift-node-guest > /dev/null 2>&1
@@ -255,7 +255,7 @@ else
   /usr/sbin/tuned-adm profile openshift-node-host > /dev/null 2>&1
 fi
 
-%preun -n tuned-profiles-atomic-enterprise-node
+%preun -n tuned-profiles-%{name}-node
 # reset the tuned profile to the recommended profile
 # $1 = 0 when we're being removed > 0 during upgrades
 if [ "$1" = 0 ]; then

--- a/rel-eng/atomic-enterprise-master.service
+++ b/rel-eng/atomic-enterprise-master.service
@@ -12,10 +12,10 @@ Requires=network.target
 Type=notify
 EnvironmentFile=/etc/sysconfig/atomic-enterprise-master
 Environment=GOTRACEBACK=crash
-ExecStart=/usr/bin/atomic-enterprise start master --config=${CONFIG_FILE} $OPTIONS
+ExecStart=/usr/bin/openshift start master --config=${CONFIG_FILE} $OPTIONS
 LimitNOFILE=131072
 LimitCORE=infinity
-WorkingDirectory=/var/lib/atomic-enterprise/
+WorkingDirectory=/var/lib/openshift/
 SyslogIdentifier=atomic-enterprise-master
 
 [Install]

--- a/rel-eng/atomic-enterprise-node.service
+++ b/rel-eng/atomic-enterprise-node.service
@@ -11,10 +11,10 @@ Documentation=https://github.com/projectatomic/appinfra-next
 Type=notify
 EnvironmentFile=/etc/sysconfig/atomic-enterprise-node
 Environment=GOTRACEBACK=crash
-ExecStart=/usr/bin/atomic-enterprise start node --config=${CONFIG_FILE} $OPTIONS
+ExecStart=/usr/bin/openshift start node --config=${CONFIG_FILE} $OPTIONS
 LimitNOFILE=65536
 LimitCORE=infinity
-WorkingDirectory=/var/lib/atomic-enterprise/
+WorkingDirectory=/var/lib/openshift/
 SyslogIdentifier=atomic-enterprise-node
 
 [Install]


### PR DESCRIPTION
Atomic Enterprise is buildable. It can be installed with ansible and
services can be run.

To test it with ansible, use [this branch](https://github.com/miminar/atomic-enterprise-ansible/tree/service-names).
