### PR TITLE
Explicitly conflict with openshift packages

### DIFF
--- a/atomic-enterprise.spec
+++ b/atomic-enterprise.spec
@@ -29,6 +29,7 @@ Source0:        %{name}-git-0.%{shortcommit}.tar.gz
 
 BuildRequires:  systemd
 BuildRequires:  golang >= 1.4
+Conflicts:      openshift
 
 
 %description
@@ -70,6 +71,7 @@ Requires:       %{name} = %{version}-%{release}
 Summary:      Atomic Enterprise Client binaries for Linux, Mac OSX, and Windows
 BuildRequires: golang-pkg-darwin-amd64
 BuildRequires: golang-pkg-windows-386
+Conflicts:     openshift-clients
 
 %description clients
 %{summary}


### PR DESCRIPTION
OpenShift can't be installed together with atomic-enterprise.

TODO:
- OpenShift spec should probably include `Provides: atomic-enterprise`.

Signed-off-by: Michal Minar miminar@redhat.com
