### PR TITLE
docker-registry: do not duplicate SecurityContextConstraints

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -308,7 +308,7 @@ echo "templates: ok"
 [ "$(openshift help start 2>&1 | grep 'Start an Atomic Enterprise all-in-one server')" ]
 [ "$(openshift help start master 2>&1 | grep 'Start an Atomic Enterprise master')" ]
 [ "$(openshift help start node 2>&1 | grep 'Start an Atomic Enterprise node')" ]
-[ "$(openshift cli help update 2>&1 | grep 'openshift')" ]
+[ "$(openshift cli help update 2>&1 | grep 'atomic-enterprise')" ]
 
 # runnable commands with required flags must error consistently
 [ "$(oc get 2>&1 | grep 'you must provide one or more resources')" ]

--- a/pkg/cmd/openshift/openshift_test.go
+++ b/pkg/cmd/openshift/openshift_test.go
@@ -12,7 +12,7 @@ func TestCommandFor(t *testing.T) {
 	}
 
 	cmd = CommandFor("unknown")
-	if cmd.Use != "openshift" {
-		t.Errorf("expected command to be openshift: %#v", cmd)
+	if cmd.Use != "atomic-enterprise" {
+		t.Errorf("expected command to be atomic-enterprise: %#v", cmd)
 	}
 }


### PR DESCRIPTION
Includes the work by @giuseppe in #38 along with testing updates. 