### PR TITLE
output: Messaging now represent the proper product.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
-	"ImportPath": "github.com/openshift/origin",
+	"ImportPath": "github.com/projectatomic/atomic-enterprise",
 	"GoVersion": "go1.4.2",
 	"Packages": [
 		"./..."

--- a/Makefile
+++ b/Makefile
@@ -93,12 +93,12 @@ ifeq ($(EXTENDED),true)
 endif
 .PHONY: test
 
-# Run All-in-one OpenShift server.
+# Run All-in-one Atomic Enterprise server.
 #
 # Example:
 #   make run
 run: build
-	$(OUT_DIR)/local/go/bin/openshift start
+	$(OUT_DIR)/local/go/bin/atomic-enterprise start
 .PHONY: run
 
 # Remove all build artifacts.
@@ -109,7 +109,7 @@ clean:
 	rm -rf $(OUT_DIR) $(OUT_PKG_DIR)
 .PHONY: clean
 
-# Build an official release of OpenShift, including the official images.
+# Build an official release of Atomic Enterprise, including the official images.
 #
 # Example:
 #   make clean

--- a/atomic-enterprise.spec
+++ b/atomic-enterprise.spec
@@ -125,7 +125,7 @@ pushd _thirdpartyhacks
 popd
 export GOPATH=$(pwd)/_build:$(pwd)/_thirdpartyhacks:%{buildroot}%{gopath}:%{gopath}
 # Build all linux components we care about
-for cmd in openshift dockerregistry
+for cmd in %{name} dockerregistry
 do
         go install -ldflags "%{ldflags}" %{import_path}/cmd/${cmd}
 done
@@ -147,11 +147,11 @@ install -d %{buildroot}%{_bindir}
 install -d %{buildroot}%{_datadir}/%{name}/linux
 #{linux,macosx,windows}
 
-mv %{buildroot}%{_datadir}/%{name} %{buildroot}%{_datadir}/openshift
+#mv %{buildroot}%{_datadir}/%{name} %{buildroot}%{_datadir}/openshift
 
 # Install linux components
 echo "+++ INSTALLING atomic-enterprise"
-install -p -m 755 _build/bin/openshift %{buildroot}%{_bindir}/%{name}
+install -p -m 755 _build/bin/%{name} %{buildroot}%{_bindir}/%{name}
 echo "+++ INSTALLING dockerregistry"
 install -p -m 755 _build/bin/dockerregistry %{buildroot}%{_bindir}/dockerregistry
 
@@ -160,8 +160,9 @@ install -p -m 755 _build/bin/dockerregistry %{buildroot}%{_bindir}/dockerregistr
 #  install -p -m 755 _build/bin/${bin} %{buildroot}%{_bindir}/${bin}
 #done
 
-# Install 'openshift' as client executable for windows and mac
-install -p -m 755 _build/bin/openshift %{buildroot}%{_datadir}/openshift/linux/oc
+# Install client executable for linux
+install -p -m 755 _build/bin/%{name} %{buildroot}%{_datadir}/%{name}/linux/oc
+# windows and mac
 #install -p -m 755 _build/bin/darwin_amd64/openshift %{buildroot}%{_datadir}/openshift/macosx/oc
 #install -p -m 755 _build/bin/windows_386/openshift.exe %{buildroot}%{_datadir}/openshift/windows/oc.exe
 #Install openshift pod
@@ -186,7 +187,7 @@ install -d -m 0755 %{buildroot}%{_prefix}/lib/tuned/%{name}-node-{guest,host}
 install -m 0644 tuned/openshift-node-guest/tuned.conf %{buildroot}%{_prefix}/lib/tuned/%{name}-node-guest/
 install -m 0644 tuned/openshift-node-host/tuned.conf %{buildroot}%{_prefix}/lib/tuned/%{name}-node-host/
 install -d -m 0755 %{buildroot}%{_mandir}/man7
-install -m 0644 tuned/man/tuned-profiles-openshift-node.7 %{buildroot}%{_mandir}/man7/tuned-profiles-%{name}-node.7
+install -m 0644 tuned/man/tuned-profiles-%{name}-node.7 %{buildroot}%{_mandir}/man7/tuned-profiles-%{name}-node.7
 
 # Install sdn scripts
 install -d -m 0755 %{buildroot}%{kube_plugin_path}
@@ -273,7 +274,7 @@ if [ "$1" = 0 ]; then
 fi
 
 %files clients
-%{_datadir}/openshift/linux/oc
+%{_datadir}/%{name}/linux/oc
 #%{_datadir}/openshift/macosx/oc
 #%{_datadir}/openshift/windows/oc.exe
 

--- a/cmd/atomic-enterprise/doc.go
+++ b/cmd/atomic-enterprise/doc.go
@@ -1,0 +1,3 @@
+// Package main contains the main executable for Atomic Enterprise `atomic-enterprise` which is an integrated
+// client and server binary.
+package main

--- a/cmd/atomic-enterprise/openshift.go
+++ b/cmd/atomic-enterprise/openshift.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/projectatomic/atomic-enterprise/pkg/cmd/openshift"
+	ae "github.com/projectatomic/atomic-enterprise/pkg/cmd/atomic-enterprise"
 	"github.com/projectatomic/atomic-enterprise/pkg/cmd/util/serviceability"
 )
 
@@ -18,7 +18,7 @@ func main() {
 	}
 
 	basename := filepath.Base(os.Args[0])
-	command := openshift.CommandFor(basename)
+	command := ae.CommandFor(basename)
 	if err := command.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/cmd/genbashcomp/gen_openshift_bash_comp.go
+++ b/cmd/genbashcomp/gen_openshift_bash_comp.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/projectatomic/atomic-enterprise/pkg/cmd/admin"
 	"github.com/projectatomic/atomic-enterprise/pkg/cmd/cli"
-	"github.com/projectatomic/atomic-enterprise/pkg/cmd/openshift"
+	"github.com/projectatomic/atomic-enterprise/pkg/cmd/atomic-enterprise"
 )
 
 func OutDir(path string) (string, error) {
@@ -44,15 +44,15 @@ func main() {
 		fmt.Fprintf(os.Stderr, "failed to get output directory: %v\n", err)
 		os.Exit(1)
 	}
-	outFile_openshift := outDir + "openshift"
-	openshift := openshift.NewCommandAtomicEnterprise("openshift")
-	openshift.GenBashCompletionFile(outFile_openshift)
+	outFile_atomic-enterprise := outDir + "atomic-enterprise"
+	atomic-enterprise := atomic-enterprise.NewCommandAtomicEnterprise("atomic-enterprise")
+	atomic-enterprise.GenBashCompletionFile(outFile_atomic-enterprise)
 
 	outFile_osc := outDir + "oc"
-	oc := cli.NewCommandCLI("oc", "openshift cli")
+	oc := cli.NewCommandCLI("oc", "atomic-enterprise cli")
 	oc.GenBashCompletionFile(outFile_osc)
 
 	outFile_osadm := outDir + "oadm"
-	oadm := admin.NewCommandAdmin("oadm", "openshift admin", ioutil.Discard)
+	oadm := admin.NewCommandAdmin("oadm", "atomic-enterprise admin", ioutil.Discard)
 	oadm.GenBashCompletionFile(outFile_osadm)
 }

--- a/cmd/genconversion/conversion.go
+++ b/cmd/genconversion/conversion.go
@@ -46,7 +46,7 @@ func main() {
 	// TODO(wojtek-t): Change the overwrites to a flag.
 	generator.OverwritePackage(*version, "")
 	for _, knownType := range api.Scheme.KnownTypes(*version) {
-		if !strings.Contains(knownType.PkgPath(), "openshift/origin") {
+		if !strings.Contains(knownType.PkgPath(), "projectatomic/atomic-enterprise") {
 			continue
 		}
 		if err := generator.GenerateConversionsForType(*version, knownType); err != nil {

--- a/cmd/gendeepcopy/deep_copy.go
+++ b/cmd/gendeepcopy/deep_copy.go
@@ -70,7 +70,7 @@ func main() {
 		generator.OverwritePackage(vals[0], vals[1])
 	}
 	for _, knownType := range api.Scheme.KnownTypes(knownVersion) {
-		if !strings.Contains(knownType.PkgPath(), "openshift/origin") {
+		if !strings.Contains(knownType.PkgPath(), "projectatomic/atomic-enterprise") {
 			continue
 		}
 		if err := generator.AddType(knownType); err != nil {

--- a/cmd/openshift/doc.go
+++ b/cmd/openshift/doc.go
@@ -1,3 +1,0 @@
-// Package main contains the main executable for OpenShift 3 `openshift` which is an integrated
-// client and server binary.
-package main

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -42,7 +42,7 @@ readonly OS_CROSS_COMPILE_PLATFORMS=(
   windows/amd64
 )
 readonly OS_CROSS_COMPILE_TARGETS=(
-  cmd/openshift
+  cmd/atomic-enterprise
 )
 readonly OS_CROSS_COMPILE_BINARIES=("${OS_CROSS_COMPILE_TARGETS[@]##*/}")
 
@@ -53,11 +53,9 @@ readonly OS_ALL_BINARIES=("${OS_ALL_TARGETS[@]##*/}")
 
 #If you update this list, be sure to get the images/origin/Dockerfile
 readonly OPENSHIFT_BINARY_SYMLINKS=(
-  openshift-router
-  openshift-deploy
-  openshift-sti-build
-  openshift-docker-build
-  openshift-gitserver
+  atomic-enterprise-router
+  atomic-enterprise-deploy
+  atomic-enterprise-gitserver
   origin
   oc
   osc
@@ -333,9 +331,9 @@ os::build::place_bins() {
 # os::build::make_openshift_binary_symlinks makes symlinks for the openshift
 # binary in _output/local/go/bin
 os::build::make_openshift_binary_symlinks() {
-  if [[ -f "${OS_LOCAL_BINPATH}/openshift" ]]; then
+  if [[ -f "${OS_LOCAL_BINPATH}/atomic-enterprise" ]]; then
     for linkname in "${OPENSHIFT_BINARY_SYMLINKS[@]}"; do
-      ln -sf "${OS_LOCAL_BINPATH}/openshift" "${OS_LOCAL_BINPATH}/${linkname}"
+      ln -sf "${OS_LOCAL_BINPATH}/atomic-enterprise" "${OS_LOCAL_BINPATH}/${linkname}"
     done
   fi
 }

--- a/pkg/auth/oauth/handlers/default_auth_handler.go
+++ b/pkg/auth/oauth/handlers/default_auth_handler.go
@@ -38,7 +38,7 @@ const (
 	// WarningHeaderMiscCode is the code for "Miscellaneous warning", which may be displayed to human users
 	WarningHeaderMiscCode = "199"
 	// WarningHeaderOpenShiftSource is the name of the agent adding the warning header
-	WarningHeaderOpenShiftSource = "OpenShift"
+	WarningHeaderOpenShiftSource = "Atomic-Enterprise"
 
 	warningHeaderCodeIndex  = 1
 	warningHeaderAgentIndex = 2

--- a/pkg/auth/oauth/handlers/default_auth_handler_test.go
+++ b/pkg/auth/oauth/handlers/default_auth_handler_test.go
@@ -196,49 +196,49 @@ func TestWarningRegex(t *testing.T) {
 		"empty": {},
 
 		// Invalid code segment
-		"code 2 numbers":   {Header: `19 OpenShift "Message goes here"`},
-		"code 4 numbers":   {Header: `1999 OpenShift "Message goes here"`},
-		"code non-numbers": {Header: `ABC OpenShift "Message goes here"`},
+		"code 2 numbers":   {Header: `19 AtomicEnterprise "Message goes here"`},
+		"code 4 numbers":   {Header: `1999 AtomicEnterprise "Message goes here"`},
+		"code non-numbers": {Header: `ABC AtomicEnterprise "Message goes here"`},
 
 		// Invalid agent segment
 		"agent missing": {Header: `199  "Message goes here"`},
 		"agent spaces":  {Header: `199 Open Shift "Message goes here"`},
 
 		// Invalid text segment
-		"text missing":       {Header: `199 OpenShift`},
-		"text unquoted":      {Header: `199 OpenShift Message`},
-		"text single quotes": {Header: `199 OpenShift 'Message'`},
-		"text bad quotes":    {Header: `199 OpenShift "Mes"sage"`},
-		"text bad escape":    {Header: `199 OpenShift "Mes\\"sage"`},
+		"text missing":       {Header: `199 AtomicEnterprise`},
+		"text unquoted":      {Header: `199 AtomicEnterprise Message`},
+		"text single quotes": {Header: `199 AtomicEnterprise 'Message'`},
+		"text bad quotes":    {Header: `199 AtomicEnterprise "Mes"sage"`},
+		"text bad escape":    {Header: `199 AtomicEnterprise "Mes\\"sage"`},
 
 		// Invalid date segment
-		"date unquoted":      {Header: `199 OpenShift "Message" Date`},
-		"date single quoted": {Header: `199 OpenShift "Message" 'Date'`},
-		"date empty":         {Header: `199 OpenShift "Message" ""`},
+		"date unquoted":      {Header: `199 AtomicEnterprise "Message" Date`},
+		"date single quoted": {Header: `199 AtomicEnterprise "Message" 'Date'`},
+		"date empty":         {Header: `199 AtomicEnterprise "Message" ""`},
 
 		// Valid segments
 		"valid no date": {
-			Header: `199 OpenShift "Message goes here"`,
+			Header: `199 AtomicEnterprise "Message goes here"`,
 			Match:  true,
-			Parts:  []string{"199", "OpenShift", "Message goes here", ""},
+			Parts:  []string{"199", "AtomicEnterprise", "Message goes here", ""},
 		},
 
 		"valid with date": {
-			Header: `199 OpenShift "Message goes here" "date"`,
+			Header: `199 AtomicEnterprise "Message goes here" "date"`,
 			Match:  true,
-			Parts:  []string{"199", "OpenShift", "Message goes here", "date"},
+			Parts:  []string{"199", "AtomicEnterprise", "Message goes here", "date"},
 		},
 
 		"valid with escaped quote": {
-			Header: `199 OpenShift "Message \" goes here" "date"`,
+			Header: `199 AtomicEnterprise "Message \" goes here" "date"`,
 			Match:  true,
-			Parts:  []string{"199", "OpenShift", `Message \" goes here`, "date"},
+			Parts:  []string{"199", "AtomicEnterprise", `Message \" goes here`, "date"},
 		},
 
 		"valid with escaped quote and slash": {
-			Header: `199 OpenShift "Message \\\" goes here" "date"`,
+			Header: `199 AtomicEnterprise "Message \\\" goes here" "date"`,
 			Match:  true,
-			Parts:  []string{"199", "OpenShift", `Message \\\" goes here`, "date"},
+			Parts:  []string{"199", "AtomicEnterprise", `Message \\\" goes here`, "date"},
 		},
 	}
 

--- a/pkg/build/admission/admission.go
+++ b/pkg/build/admission/admission.go
@@ -20,7 +20,7 @@ func init() {
 	admission.RegisterPlugin("BuildByStrategy", func(c kclient.Interface, config io.Reader) (admission.Interface, error) {
 		osClient, ok := c.(client.Interface)
 		if !ok {
-			return nil, errors.New("client is not an OpenShift client")
+			return nil, errors.New("client is not an Atomic Enterprise client")
 		}
 		return NewBuildByStrategy(osClient), nil
 	})

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -277,5 +277,5 @@ func DefaultOpenShiftUserAgent() string {
 	version := version.Get().GitVersion
 	seg := strings.SplitN(version, "-", 2)
 	version = seg[0]
-	return fmt.Sprintf("%s/%s (%s/%s) openshift/%s", path.Base(os.Args[0]), version, runtime.GOOS, runtime.GOARCH, commit)
+	return fmt.Sprintf("%s/%s (%s/%s) atomic-enterprise/%s", path.Base(os.Args[0]), version, runtime.GOOS, runtime.GOARCH, commit)
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -23,7 +23,7 @@ func TestUserAgent(t *testing.T) {
 	c.DeploymentConfigs("test").Get("other")
 
 	header := <-ch
-	if !strings.Contains(header, "openshift/") || !strings.Contains(header, "client.test/") {
+	if !strings.Contains(header, "atomic-enterprise/") || !strings.Contains(header, "client.test/") {
 		t.Fatalf("no user agent header: %s", header)
 	}
 }

--- a/pkg/cmd/admin/node/evacuate.go
+++ b/pkg/cmd/admin/node/evacuate.go
@@ -55,7 +55,7 @@ func (e *EvacuateOptions) RunEvacuate(node *kapi.Node) error {
 	// we may not be able to recover in some cases to mark the node back to schedulable. To avoid these cases, we recommend
 	// user to explicitly set the node to schedulable/unschedulable.
 	if !node.Spec.Unschedulable {
-		return fmt.Errorf("Node '%s' must be unschedulable to perform evacuation.\nYou can mark the node unschedulable with 'openshift admin manage-node %s --schedulable=false'", node.ObjectMeta.Name, node.ObjectMeta.Name)
+		return fmt.Errorf("Node '%s' must be unschedulable to perform evacuation.\nYou can mark the node unschedulable with 'atomic-enterprise admin manage-node %s --schedulable=false'", node.ObjectMeta.Name, node.ObjectMeta.Name)
 	}
 
 	labelSelector, err := labels.Parse(e.Options.PodSelector)

--- a/pkg/cmd/admin/prune/images.go
+++ b/pkg/cmd/admin/prune/images.go
@@ -190,7 +190,7 @@ func NewCmdPruneImages(f *clientcmd.Factory, parentName, name string, out io.Wri
 	cmd.Flags().BoolVar(&cfg.Confirm, "confirm", cfg.Confirm, "Specify that image pruning should proceed. Defaults to false, displaying what would be deleted but not actually deleting anything.")
 	cmd.Flags().DurationVar(&cfg.KeepYoungerThan, "keep-younger-than", cfg.KeepYoungerThan, "Specify the minimum age of a build for it to be considered a candidate for pruning.")
 	cmd.Flags().IntVar(&cfg.TagRevisionsToKeep, "keep-tag-revisions", cfg.TagRevisionsToKeep, "Specify the number of image revisions for a tag in an image stream that will be preserved.")
-	cmd.Flags().StringVar(&cfg.CABundle, "certificate-authority", cfg.CABundle, "The path to a certificate authority bundle to use when communicating with the OpenShift-managed registries. Defaults to the certificate authority data from the current user's config file.")
+	cmd.Flags().StringVar(&cfg.CABundle, "certificate-authority", cfg.CABundle, "The path to a certificate authority bundle to use when communicating with the Atomic-Enterprise-managed registries. Defaults to the certificate authority data from the current user's config file.")
 	cmd.Flags().StringVar(&cfg.RegistryUrlOverride, "registry-url", cfg.RegistryUrlOverride, "The address to use when contacting the registry, instead of using the default value. This is useful if you can't resolve or reach the registry (e.g.; the default is a cluster-internal URL) but you do have an alternative route that works.")
 
 	return cmd

--- a/pkg/cmd/admin/registry/registry.go
+++ b/pkg/cmd/admin/registry/registry.go
@@ -88,7 +88,7 @@ func NewCmdRegistry(f *clientcmd.Factory, parentName, name string, out io.Writer
 
 	cmd := &cobra.Command{
 		Use:     name,
-		Short:   "Install the OpenShift Docker registry",
+		Short:   "Install the Atomic Enterprise Docker registry",
 		Long:    registryLong,
 		Example: fmt.Sprintf(registryExample, parentName, name),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/admin/router/router.go
+++ b/pkg/cmd/admin/router/router.go
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	routerLong = `Install or configure an OpenShift router
+	routerLong = `Install or configure an Atomic Enterprise router
 
-This command helps to setup an OpenShift router to take edge traffic and balance it to
+This command helps to setup an Atomic Enterprise router to take edge traffic and balance it to
 your application. With no arguments, the command will check for an existing router
 service called 'router' and create one if it does not exist. If you want to test whether
 a router has already been created add the --dry-run flag and the command will exit with
@@ -90,7 +90,7 @@ func NewCmdRouter(f *clientcmd.Factory, parentName, name string, out io.Writer) 
 
 	cmd := &cobra.Command{
 		Use:     fmt.Sprintf("%s [NAME]", name),
-		Short:   "Install an OpenShift router",
+		Short:   "Install an Atomic Enterprise router",
 		Long:    routerLong,
 		Example: fmt.Sprintf(routerExample, parentName, name),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/atomic-enterprise/openshift.go
+++ b/pkg/cmd/atomic-enterprise/openshift.go
@@ -28,7 +28,7 @@ import (
 
 const openshiftLong = `Atomic Enterprise Platform.
 
-OpenShift helps you build, deploy, and manage your applications. To start an all-in-one server, run:
+Atomic Enterprise helps you build, deploy, and manage your applications. To start an all-in-one server, run:
 
   $ atomic-enterprise start &
 
@@ -49,15 +49,11 @@ func CommandFor(basename string) *cobra.Command {
 	}
 
 	switch basename {
-	case "openshift-router":
+	case "atomic-enterprise-router":
 		cmd = irouter.NewCommandTemplateRouter(basename)
-	case "openshift-deploy":
+	case "atomic-enterprise-deploy":
 		cmd = deployer.NewCommandDeployer(basename)
-	case "openshift-sti-build":
-		cmd = builder.NewCommandSTIBuilder(basename)
-	case "openshift-docker-build":
-		cmd = builder.NewCommandDockerBuilder(basename)
-	case "openshift-gitserver":
+	case "atomic-enterprise-gitserver":
 		cmd = gitserver.NewCommandGitServer(basename)
 	case "oc", "osc":
 		cmd = cli.NewCommandCLI(basename, basename)

--- a/pkg/cmd/atomic-enterprise/openshift_test.go
+++ b/pkg/cmd/atomic-enterprise/openshift_test.go
@@ -6,8 +6,8 @@ import (
 )
 
 func TestCommandFor(t *testing.T) {
-	cmd := CommandFor("openshift-router")
-	if !strings.HasPrefix(cmd.Use, "openshift-router ") {
+	cmd := CommandFor("atomic-enterprise-router")
+	if !strings.HasPrefix(cmd.Use, "atomic-enterprise-router ") {
 		t.Errorf("expected command to start with prefix: %#v", cmd)
 	}
 

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -29,7 +29,7 @@ To create a new application, you can use the example app source. Login to your s
 run new-app:
 
   $ %[1]s login
-  $ %[1]s new-app openshift/ruby-20-centos7~https://github.com/openshift/ruby-hello-world.git
+  $ %[1]s new-app atomicenterprise/ruby-20-centos7~https://github.com/openshift/ruby-hello-world.git
 
 This will create an application based on the Docker image 'openshift/ruby-20-centos7' that builds
 the source code at 'github.com/openshift/ruby-hello-world.git'. To start the build, run
@@ -154,7 +154,7 @@ func NewCmdKubectl(name string, out io.Writer) *cobra.Command {
 	cmds.Aliases = []string{"kubectl"}
 	cmds.Use = name
 	cmds.Short = "Kubernetes cluster management via kubectl"
-	cmds.Long = cmds.Long + "\n\nThis command is provided for direct management of the Kubernetes cluster OpenShift runs on."
+	cmds.Long = cmds.Long + "\n\nThis command is provided for direct management of the Kubernetes cluster Atomic Enterprise runs on."
 	flags.VisitAll(func(flag *pflag.Flag) {
 		if f := cmds.PersistentFlags().Lookup(flag.Name); f == nil {
 			cmds.PersistentFlags().AddFlag(flag)

--- a/pkg/cmd/cli/cmd/config.go
+++ b/pkg/cmd/cli/cmd/config.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	configLong = `Manages the OpenShift config files.
+	configLong = `Manages the Atomic Enterprise config files.
 
 Reference: https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/kubeconfig-file.md`
 

--- a/pkg/cmd/cli/cmd/login.go
+++ b/pkg/cmd/cli/cmd/login.go
@@ -19,9 +19,9 @@ import (
 )
 
 const (
-	loginLong = `Log in to an OpenShift server and save config for future use
+	loginLong = `Log in to an Atomic Enterprise server and save config for future use
 
-First-time users of the OpenShift client should run this command to connect to a server,
+First-time users of the Atomic Enterprise client should run this command to connect to a server,
 establish an authenticated session, and save connection to the configuration file. The
 default configuration will be saved to your home directory under
 ".kube/config".
@@ -49,7 +49,7 @@ func NewCmdLogin(fullName string, f *osclientcmd.Factory, reader io.Reader, out 
 
 	cmds := &cobra.Command{
 		Use:     "login [URL]",
-		Short:   "Log in to an OpenShift server",
+		Short:   "Log in to an Atomic Enterprise server",
 		Long:    loginLong,
 		Example: fmt.Sprintf(loginExample, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -183,7 +183,7 @@ func RunLogin(cmd *cobra.Command, options *LoginOptions) error {
 	}
 
 	if newFileCreated {
-		fmt.Fprintln(options.Out, "Welcome to OpenShift! See 'oc help' to get started.")
+		fmt.Fprintln(options.Out, "Welcome to Atomic Enterprise! See 'oc help' to get started.")
 	}
 	return nil
 }

--- a/pkg/cmd/cli/cmd/loginoptions.go
+++ b/pkg/cmd/cli/cmd/loginoptions.go
@@ -87,7 +87,7 @@ func (o *LoginOptions) getClientConfig() (*kclient.Config, error) {
 		if cmdutil.IsTerminal(o.Reader) {
 			for !o.serverProvided() {
 				defaultServer := defaultClusterURL
-				promptMsg := fmt.Sprintf("OpenShift server [%s]: ", defaultServer)
+				promptMsg := fmt.Sprintf("Atomic Enterprise server [%s]: ", defaultServer)
 
 				o.Server = cmdutil.PromptForStringWithDefault(o.Reader, defaultServer, promptMsg)
 			}

--- a/pkg/cmd/cli/cmd/logout.go
+++ b/pkg/cmd/cli/cmd/logout.go
@@ -36,7 +36,7 @@ your ticket or client certificate will not be removed from the current system si
 are typically managed by other programs. Instead, you can delete your config file to remove
 the local copy of that certificate or the record of your server login.
 
-After logging out, if you want to log back into the OpenShift server, try '%[1]s'.`
+After logging out, if you want to log back into the Atomic Enterprise server, try '%[1]s'.`
 
 	logoutExample = `  // Logout
   $ %[1]s`

--- a/pkg/cmd/cli/cmd/newapp.go
+++ b/pkg/cmd/cli/cmd/newapp.go
@@ -29,14 +29,14 @@ type usage interface {
 var errExit = fmt.Errorf("exit directly")
 
 const (
-	newAppLong = `Create a new application in OpenShift by specifying source code, templates, and/or images.
+	newAppLong = `Create a new application in Atomic Enterprise by specifying source code, templates, and/or images.
 
 This command will try to build up the components of an application using images, templates,
 or code that has a public repository. It will lookup the images on the local Docker installation
-(if available), a Docker registry, or an OpenShift image stream.
+(if available), a Docker registry, or an Atomic Enterprise image stream.
 If you specify a source code URL, it will set up a build that takes your source code and converts
 it into an image that can run inside of a pod. Local source must be in a git repository that has a
-remote repository that the OpenShift instance can see. The images will be deployed via a deployment
+remote repository that the Atomic Enterprise instance can see. The images will be deployed via a deployment
 configuration, and a service will be connected to the first public port of the app. You may either specify
 components using the various existing flags or let new-app autodetect what kind of components
 you have provided.
@@ -48,7 +48,7 @@ application is created.`
   $ %[1]s new-app . --docker-image=repo/langimage
 
   // Create a Ruby application based on the provided [image]~[source code] combination
-  $ %[1]s new-app openshift/ruby-20-centos7~https://github.com/openshift/ruby-hello-world.git
+  $ %[1]s new-app atomicenterprise/ruby-20-centos7~https://github.com/openshift/ruby-hello-world.git
 
   // Use the public Docker Hub MySQL image to create an app. Generated artifacts will be labeled with db=mysql
   $ %[1]s new-app mysql -l db=mysql
@@ -91,9 +91,9 @@ func NewCmdNewApplication(fullName string, f *clientcmd.Factory, out io.Writer) 
 
 	cmd.Flags().Var(&config.SourceRepositories, "code", "Source code to use to build this application.")
 	cmd.Flags().StringVar(&config.ContextDir, "context-dir", "", "Context directory to be used for the build.")
-	cmd.Flags().VarP(&config.ImageStreams, "image", "i", "Name of an OpenShift image stream to use in the app.")
+	cmd.Flags().VarP(&config.ImageStreams, "image", "i", "Name of an Atomic Enterprise image stream to use in the app.")
 	cmd.Flags().Var(&config.DockerImages, "docker-image", "Name of a Docker image to include in the app.")
-	cmd.Flags().Var(&config.Templates, "template", "Name of an OpenShift stored template to use in the app.")
+	cmd.Flags().Var(&config.Templates, "template", "Name of an Atomic Enterprise stored template to use in the app.")
 	cmd.Flags().VarP(&config.TemplateFiles, "file", "f", "Path to a template file to use for the app.")
 	cmd.Flags().VarP(&config.TemplateParameters, "param", "p", "Specify a list of key value pairs (eg. -p FOO=BAR,BAR=FOO) to set/override parameter values in the template.")
 	cmd.Flags().Var(&config.Groups, "group", "Indicate components that should be grouped together as <comp1>+<comp2>.")
@@ -161,7 +161,7 @@ func RunNewApplication(fullName string, f *clientcmd.Factory, out io.Writer, c *
 					continue
 				}
 				hasMissingRepo = true
-				fmt.Fprintf(c.Out(), "WARNING: We created an ImageStream %q, but it does not look like a Docker registry has been integrated with the OpenShift server. Automatic builds and deployments depend on that integration to detect new images and will not function properly.\n", t.Name)
+				fmt.Fprintf(c.Out(), "WARNING: We created an ImageStream %q, but it does not look like a Docker registry has been integrated with the Atomic Enterprise server. Automatic builds and deployments depend on that integration to detect new images and will not function properly.\n", t.Name)
 			}
 		}
 	}

--- a/pkg/cmd/cli/cmd/request_project.go
+++ b/pkg/cmd/cli/cmd/request_project.go
@@ -29,7 +29,7 @@ type NewProjectOptions struct {
 }
 
 const (
-	requestProjectLong = `Create a new project for yourself in OpenShift with you as the project admin.
+	requestProjectLong = `Create a new project for yourself in Atomic Enterprise with you as the project admin.
 
 Assuming your cluster admin has granted you permission, this command will 
 create a new project for you and assign you as the project admin.  You must 

--- a/pkg/cmd/cli/cmd/tag.go
+++ b/pkg/cmd/cli/cmd/tag.go
@@ -24,11 +24,11 @@ stream, or a Docker image pull spec, and set it as the most recent image for a
 tag in 1 or more other image streams. It is similar to the 'docker tag'
 command, but it operates on image streams instead.`
 
-	tagExample = `  // Tag the current image for the image stream 'openshift/ruby' and tag '2.0' into the image stream 'yourproject/ruby with tag 'tip':
-  $ %[1]s tag openshift/ruby:2.0 yourproject/ruby:tip
+	tagExample = `  // Tag the current image for the image stream 'atomicenterprise/ruby' and tag '2.0' into the image stream 'yourproject/ruby with tag 'tip':
+  $ %[1]s tag atomicenterprise/ruby:2.0 yourproject/ruby:tip
 
   // Tag a specific image:
-  $ %[1]s tag openshift/ruby@sha256:6b646fa6bf5e5e4c7fa41056c27910e679c03ebe7f93e361e6515a9da7e258cc yourproject/ruby:tip
+  $ %[1]s tag atomicenterprise/ruby@sha256:6b646fa6bf5e5e4c7fa41056c27910e679c03ebe7f93e361e6515a9da7e258cc yourproject/ruby:tip
 
   // Tag an external Docker image:
   $ %[1]s tag --source=docker projectatomic/atomic-enterprise:latest yourproject/ruby:tip`

--- a/pkg/cmd/cli/cmd/types.go
+++ b/pkg/cmd/cli/cmd/types.go
@@ -171,16 +171,16 @@ func writeTerm(w io.Writer, t term) {
 
 var (
 	typesLong = D(`
-    OpenShift Concepts and Types
+    Atomic Enterprise Concepts and Types
 
-    OpenShift helps developers and operators build, test, and deploy applications in
+    Atomic Enterprise helps developers and operators build, test, and deploy applications in
     a containerized cloud environment. Applications may be composed of all of the
     components below, although most developers will be concerned with Services,
     Deployments, and Builds for delivering changes.
 
     Concepts:
 
-    %[1]sFor more, see https://docs.openshift.com
+    %[1]sFor more, see https://projectatomic.io
   `)
 
 	typesExample = `  // View all projects you have access to
@@ -203,7 +203,7 @@ func NewCmdTypes(fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Co
 	}
 	cmd := &cobra.Command{
 		Use:     "types",
-		Short:   "An introduction to the concepts and types in OpenShift",
+		Short:   "An introduction to the concepts and types in Atomic Enterprise",
 		Long:    fmt.Sprintf(typesLong, buf.String()),
 		Example: fmt.Sprintf(typesExample, fullName),
 		Run:     ocutil.DefaultSubCommandRun(out),

--- a/pkg/cmd/cli/secrets/dockercfg.go
+++ b/pkg/cmd/cli/secrets/dockercfg.go
@@ -27,7 +27,7 @@ When using the Docker command line to push images, you can authenticate to a giv
   'docker login DOCKER_REGISTRY_SERVER --username=DOCKER_USER --password=DOCKER_PASSWORD --email=DOCKER_EMAIL'.
 That produces a ~/.dockercfg file that is used by subsequent 'docker push' and 'docker pull' commands to authenticate to the registry.
 
-When using OpenShift, you may have a Docker registry that requires authentication.  In order for the nodes to pull images on your behalf, they have to have the credentials.  You can provide this information by creating a dockercfg secret and attaching it to your service account.
+When using Atomic Enterprise, you may have a Docker registry that requires authentication.  In order for the nodes to pull images on your behalf, they have to have the credentials.  You can provide this information by creating a dockercfg secret and attaching it to your service account.
 
 If you don't already have a .dockercfg file, you can create a dockercfg secret directly by using:
 

--- a/pkg/cmd/experimental/buildchain/buildchain.go
+++ b/pkg/cmd/experimental/buildchain/buildchain.go
@@ -26,22 +26,22 @@ Tag and namespace are optional and if they are not specified, 'latest' and the
 default namespace will be used respectively.`
 
 	buildChainExample = `  // Build dependency tree for the specified image stream and tag
-  $ openshift ex build-chain [image-stream]:[tag]
+  $ atomic-enterprise ex build-chain [image-stream]:[tag]
 
   // Build dependency trees for all tags in the specified image stream
-  $ openshift ex build-chain [image-stream] --all-tags
+  $ atomic-enterprise ex build-chain [image-stream] --all-tags
 
   // Build the dependency tree using tag 'latest' in 'testing' namespace
-  $ openshift ex build-chain [image-stream] -n testing
+  $ atomic-enterprise ex build-chain [image-stream] -n testing
 
   // Build the dependency tree and output it in DOT syntax
-  $ openshift ex build-chain [image-stream] -o dot
+  $ atomic-enterprise ex build-chain [image-stream] -o dot
 
   // Build dependency trees for all image streams in the current namespace
-  $ openshift ex build-chain
+  $ atomic-enterprise ex build-chain
 
   // Build dependency trees for all image streams across all namespaces
-  $ openshift ex build-chain --all`
+  $ atomic-enterprise ex build-chain --all`
 )
 
 // Node is a representation of an image stream inside a tree

--- a/pkg/cmd/experimental/ipfailover/ipfailover.go
+++ b/pkg/cmd/experimental/ipfailover/ipfailover.go
@@ -16,7 +16,7 @@ import (
 const (
 	ipFailover_long = `Configure or view IP Failover configuration
 
-This command helps to setup IP Failover configuration for an OpenShift
+This command helps to setup IP Failover configuration for an Atomic Enterprise 
 environment. An administrator can configure IP failover on an entire
 cluster or as would normally be the case on a subset of nodes (as defined
 via a labeled selector).

--- a/pkg/cmd/infra/deployer/deployer.go
+++ b/pkg/cmd/infra/deployer/deployer.go
@@ -25,7 +25,7 @@ import (
 const (
 	deployerLong = `Perform a Deployment.
 
-This command makes calls to OpenShift to perform a deployment as described by a DeploymentConfig.`
+This command makes calls to Atomic Enterprise to perform a deployment as described by a DeploymentConfig.`
 )
 
 type config struct {
@@ -42,7 +42,7 @@ func NewCommandDeployer(name string) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("%s%s", name, clientcmd.ConfigSyntax),
-		Short: "Run the OpenShift deployer",
+		Short: "Run the Atomic Enterprise deployer",
 		Long:  deployerLong,
 		Run: func(c *cobra.Command, args []string) {
 			_, kClient, err := cfg.Config.Clients()

--- a/pkg/cmd/infra/gitserver/gitserver.go
+++ b/pkg/cmd/infra/gitserver/gitserver.go
@@ -16,7 +16,7 @@ const longCommandDesc = `
 Start a Git server
 
 This command launches a Git HTTP/HTTPS server that supports push and pull, mirroring,
-and automatic creation of OpenShift applications on push.
+and automatic creation of Atomic Enterprise applications on push.
 
 %[1]s
 `

--- a/pkg/cmd/server/admin/create_bootstrappolicy_file.go
+++ b/pkg/cmd/server/admin/create_bootstrappolicy_file.go
@@ -22,7 +22,7 @@ import (
 const (
 	DefaultPolicyFile                    = "openshift.local.config/master/policy.json"
 	CreateBootstrapPolicyFileCommand     = "create-bootstrap-policy-file"
-	CreateBootstrapPolicyFileFullCommand = "openshift admin " + CreateBootstrapPolicyFileCommand
+	CreateBootstrapPolicyFileFullCommand = "atomic-enterprise admin " + CreateBootstrapPolicyFileCommand
 )
 
 type CreateBootstrapPolicyFileOptions struct {
@@ -36,7 +36,7 @@ func NewCommandCreateBootstrapPolicyFile(commandName string, fullName string, ou
 
 	cmd := &cobra.Command{
 		Use:   commandName,
-		Short: "Create bootstrap policy for OpenShift",
+		Short: "Create bootstrap policy for Atomic Enterprise",
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.Validate(args); err != nil {
 				kcmdutil.CheckErr(kcmdutil.UsageError(cmd, err.Error()))
@@ -52,7 +52,7 @@ func NewCommandCreateBootstrapPolicyFile(commandName string, fullName string, ou
 
 	flags.StringVar(&options.File, "filename", DefaultPolicyFile, "The policy template file that will be written with roles and bindings.")
 
-	flags.StringVar(&options.OpenShiftSharedResourcesNamespace, "openshift-namespace", "openshift", "Namespace for shared openshift resources.")
+	flags.StringVar(&options.OpenShiftSharedResourcesNamespace, "atomic-enterprise-namespace", "atomic-enterprise", "Namespace for shared atomic-enterprise resources.")
 
 	return cmd
 }
@@ -65,7 +65,7 @@ func (o CreateBootstrapPolicyFileOptions) Validate(args []string) error {
 		return errors.New("filename must be provided")
 	}
 	if len(o.OpenShiftSharedResourcesNamespace) == 0 {
-		return errors.New("openshift-namespace must be provided")
+		return errors.New("atomic-enterprise-namespace must be provided")
 	}
 
 	return nil

--- a/pkg/cmd/server/admin/create_client.go
+++ b/pkg/cmd/server/admin/create_client.go
@@ -32,7 +32,7 @@ type CreateClientOptions struct {
 }
 
 const createClientLong = `
-Create a client configuration for connecting to OpenShift
+Create a client configuration for connecting to Atomic Enterprise 
 
 This command creates a folder containing a client certificate, a client key,
 a server certificate authority, and a .kubeconfig file for connecting to the

--- a/pkg/cmd/server/admin/create_mastercerts.go
+++ b/pkg/cmd/server/admin/create_mastercerts.go
@@ -18,9 +18,9 @@ import (
 )
 
 const CreateMasterCertsCommandName = "create-master-certs"
-const masterCertLong = `Create keys and certificates for an OpenShift master
+const masterCertLong = `Create keys and certificates for an Atomic Enterprise master
 
-This command creates keys and certs necessary to run a secure OpenShift master.
+This command creates keys and certs necessary to run a secure Atomic Enterprise master.
 It also creates keys, certificates, and configuration necessary for most
 related infrastructure components that are clients to the master.
 See the related "create-node-config" command for generating per-node config.
@@ -37,7 +37,7 @@ All files are expected or created in standard locations under the cert-dir.
 Note that the certificate authority (CA aka "signer") generated automatically
 is self-signed. In production usage, administrators are more likely to
 want to generate signed certificates separately rather than rely on an
-OpenShift-generated CA. Alternatively, start with an existing signed CA and
+Atomic Enterprise-generated CA. Alternatively, start with an existing signed CA and
 have this command use it to generate valid certificates.
 
 This command would usually only be used once at installation. If you
@@ -59,7 +59,7 @@ Regardless of --overwrite, the master server key/cert will be updated
 if --hostnames does not match the current certificate.
 Regardless of --overwrite, .kubeconfig files will be updated every time this
 command is run, so always specify --master (and if needed, --public-master).
-This is designed to match the behavior of "openshift start" which rewrites
+This is designed to match the behavior of "atomic-enterprise start" which rewrites
 certs/confs for certain configuration changes.
 `
 
@@ -81,7 +81,7 @@ func NewCommandCreateMasterCerts(commandName string, fullName string, out io.Wri
 
 	cmd := &cobra.Command{
 		Use:   commandName,
-		Short: "Create certificates for an OpenShift master",
+		Short: "Create certificates for an Atomic Enterprise master",
 		Long:  fmt.Sprintf(masterCertLong, fullName),
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.Validate(args); err != nil {

--- a/pkg/cmd/server/admin/create_signercert.go
+++ b/pkg/cmd/server/admin/create_signercert.go
@@ -35,10 +35,10 @@ func BindSignerCertOptions(options *CreateSignerCertOptions, flags *pflag.FlagSe
 
 const createSignerLong = `
 Create a self-signed CA key/cert for signing certificates used by
-OpenShift components.
+Atomic Enterprise components.
 
 This is mainly intended for development/trial deployments as production
-deployments of OpenShift should utilize properly signed certificates
+deployments of Atomic Enterprise should utilize properly signed certificates
 (generated separately) or start with a properly signed CA.
 `
 

--- a/pkg/cmd/server/admin/default_certs.go
+++ b/pkg/cmd/server/admin/default_certs.go
@@ -24,7 +24,7 @@ type ClientCertInfo struct {
 }
 
 func DefaultSignerName() string {
-	return fmt.Sprintf("%s@%d", "openshift-signer", time.Now().Unix())
+	return fmt.Sprintf("%s@%d", "atomic-enterprise-signer", time.Now().Unix())
 }
 
 func DefaultRootCAFile(certDir string) string {

--- a/pkg/cmd/server/origin/master.go
+++ b/pkg/cmd/server/origin/master.go
@@ -338,7 +338,7 @@ func (c *MasterConfig) InstallProtectedAPI(container *restful.Container) []strin
 		if err := c.api_v1beta3(storage).InstallREST(container); err != nil {
 			glog.Fatalf("Unable to initialize v1beta3 API: %v", err)
 		}
-		messages = append(messages, fmt.Sprintf("Started OpenShift API at %%s%s", OpenShiftAPIPrefixV1Beta3))
+		messages = append(messages, fmt.Sprintf("Started Atomic Enterprise API at %%s%s", OpenShiftAPIPrefixV1Beta3))
 		legacyAPIVersions = append(legacyAPIVersions, OpenShiftAPIV1Beta3)
 	}
 
@@ -346,7 +346,7 @@ func (c *MasterConfig) InstallProtectedAPI(container *restful.Container) []strin
 		if err := c.api_v1(storage).InstallREST(container); err != nil {
 			glog.Fatalf("Unable to initialize v1 API: %v", err)
 		}
-		messages = append(messages, fmt.Sprintf("Started OpenShift API at %%s%s (experimental)", OpenShiftAPIPrefixV1))
+		messages = append(messages, fmt.Sprintf("Started Atomic Enterprise API at %%s%s (experimental)", OpenShiftAPIPrefixV1))
 		currentAPIVersions = append(currentAPIVersions, OpenShiftAPIV1)
 	}
 
@@ -356,9 +356,9 @@ func (c *MasterConfig) InstallProtectedAPI(container *restful.Container) []strin
 		case "/":
 			root = svc
 		case OpenShiftAPIPrefixV1Beta3:
-			svc.Doc("OpenShift REST API, version v1beta3").ApiVersion("v1beta3")
+			svc.Doc("Atomic Enterprise REST API, version v1beta3").ApiVersion("v1beta3")
 		case OpenShiftAPIPrefixV1:
-			svc.Doc("OpenShift REST API, version v1").ApiVersion("v1")
+			svc.Doc("Atomic Enterprise REST API, version v1").ApiVersion("v1")
 		}
 	}
 
@@ -402,9 +402,9 @@ func initReadinessCheckRoute(root *restful.WebService, path string, readyFunc fu
 		} else {
 			resp.ResponseWriter.WriteHeader(http.StatusServiceUnavailable)
 		}
-	}).Doc("return the readiness state of OpenShift").
-		Returns(http.StatusOK, "if OpenShift is ready", nil).
-		Returns(http.StatusServiceUnavailable, "if OpenShift is not ready", nil).
+	}).Doc("return the readiness state of Atomic Enterprise").
+		Returns(http.StatusOK, "if Atomic Enterprise is ready", nil).
+		Returns(http.StatusServiceUnavailable, "if Atomic Enterprise is not ready", nil).
 		Produces(restful.MIME_JSON))
 }
 
@@ -983,7 +983,7 @@ func (c *MasterConfig) RunDNSServer() {
 
 	cmdutil.WaitForSuccessfulDial(false, "tcp", c.Options.DNSConfig.BindAddress, 100*time.Millisecond, 100*time.Millisecond, 100)
 
-	glog.Infof("OpenShift DNS listening at %s", c.Options.DNSConfig.BindAddress)
+	glog.Infof("Atomic Enterprise DNS listening at %s", c.Options.DNSConfig.BindAddress)
 }
 
 // RunProjectCache populates project cache, used by scheduler and project admission controller.

--- a/pkg/cmd/server/start/command_test.go
+++ b/pkg/cmd/server/start/command_test.go
@@ -212,7 +212,7 @@ func executeMasterCommand(args []string) *MasterArgs {
 	argsToUse = append(argsToUse, "--create-certs=false")
 
 	root := &cobra.Command{
-		Use:   "openshift",
+		Use:   "atomic-enterprise",
 		Short: "test",
 		Long:  "",
 		Run: func(c *cobra.Command, args []string) {
@@ -241,7 +241,7 @@ func executeAllInOneCommandWithConfigs(args []string) (*MasterArgs, *configapi.M
 	argsToUse = append(argsToUse, "--create-certs=false")
 
 	root := &cobra.Command{
-		Use:   "openshift",
+		Use:   "atomic-enterprise",
 		Short: "test",
 		Long:  "",
 		Run: func(c *cobra.Command, args []string) {
@@ -249,7 +249,7 @@ func executeAllInOneCommandWithConfigs(args []string) (*MasterArgs, *configapi.M
 		},
 	}
 
-	openshiftStartCommand, cfg := NewCommandStartAllInOne("openshift start", os.Stdout)
+	openshiftStartCommand, cfg := NewCommandStartAllInOne("atomic-enterprise start", os.Stdout)
 	root.AddCommand(openshiftStartCommand)
 	root.SetArgs(argsToUse)
 	root.Execute()

--- a/pkg/cmd/server/start/kubernetes/kubelet.go
+++ b/pkg/cmd/server/start/kubernetes/kubelet.go
@@ -13,7 +13,7 @@ import (
 
 const kubeletLog = `Start Kubelet
 
-This command launches a Kubelet. All options are exposed. Use 'openshift start node' for
+This command launches a Kubelet. All options are exposed. Use 'atomic-enterprise start node' for
 starting from a configuration file.`
 
 // NewKubeletCommand provides a CLI handler for the 'kubelet' command

--- a/pkg/cmd/server/start/master_args.go
+++ b/pkg/cmd/server/start/master_args.go
@@ -72,7 +72,7 @@ type MasterArgs struct {
 
 // BindMasterArgs binds the options to the flags with prefix + default flag names
 func BindMasterArgs(args *MasterArgs, flags *pflag.FlagSet, prefix string) {
-	flags.Var(&args.MasterAddr, prefix+"master", "The master address for use by OpenShift components (host, host:port, or URL). Scheme and port default to the --listen scheme and port. When unset, attempt to use the first public IPv4 non-loopback address registered on this host.")
+	flags.Var(&args.MasterAddr, prefix+"master", "The master address for use by Atomic Enterprise components (host, host:port, or URL). Scheme and port default to the --listen scheme and port. When unset, attempt to use the first public IPv4 non-loopback address registered on this host.")
 	flags.Var(&args.MasterPublicAddr, prefix+"public-master", "The master address for use by public clients, if different (host, host:port, or URL). Defaults to same as --master.")
 	flags.BoolVar(&args.OpenshiftEnabled, prefix+"openshift-enabled", false, "Controls if openshift additions are enabled or not.")
 	flags.Var(&args.EtcdAddr, prefix+"etcd", "The address of the etcd server (host, host:port, or URL). If specified, no built-in etcd will be started.")

--- a/pkg/cmd/util/serviceability/panic.go
+++ b/pkg/cmd/util/serviceability/panic.go
@@ -14,7 +14,7 @@ func BehaviorOnPanic(mode string) (fn func()) {
 	fn = func() {}
 	switch {
 	case mode == "crash":
-		glog.Infof("OpenShift will terminate as soon as a panic occurs.")
+		glog.Infof("Atomic Enterprise will terminate as soon as a panic occurs.")
 		util.ReallyCrash = true
 	case strings.HasPrefix(mode, "sentry:"):
 		url := strings.TrimPrefix(mode, "sentry:")
@@ -23,7 +23,7 @@ func BehaviorOnPanic(mode string) (fn func()) {
 			glog.Errorf("Unable to start Sentry for panic tracing: %v", err)
 			return
 		}
-		glog.Infof("OpenShift will log all panics and errors to Sentry.")
+		glog.Infof("Atomic Enterprise will log all panics and errors to Sentry.")
 		util.PanicHandlers = append(util.PanicHandlers, m.CapturePanic)
 		util.ErrorHandlers = append(util.ErrorHandlers, m.CaptureError)
 		fn = func() {

--- a/pkg/dockerregistry/server/openshiftclient.go
+++ b/pkg/dockerregistry/server/openshiftclient.go
@@ -17,7 +17,7 @@ func NewUserOpenShiftClient(bearerToken string) (*osclient.Client, error) {
 	config.BearerToken = bearerToken
 	client, err := osclient.New(config)
 	if err != nil {
-		return nil, fmt.Errorf("error creating OpenShift client: %s", err)
+		return nil, fmt.Errorf("error creating Atomic Enterprise client: %s", err)
 	}
 	return client, nil
 }
@@ -41,7 +41,7 @@ func NewRegistryOpenShiftClient() (*osclient.Client, error) {
 	}
 	client, err := osclient.New(config)
 	if err != nil {
-		return nil, fmt.Errorf("error creating OpenShift client: %s", err)
+		return nil, fmt.Errorf("error creating Atomic Enterprise client: %s", err)
 	}
 	return client, nil
 }

--- a/pkg/dockerregistry/server/repositorymiddleware.go
+++ b/pkg/dockerregistry/server/repositorymiddleware.go
@@ -22,7 +22,7 @@ import (
 )
 
 func init() {
-	repomw.Register("openshift", repomw.InitFunc(newRepository))
+	repomw.Register("atomicenterprise", repomw.InitFunc(newRepository))
 }
 
 type repository struct {
@@ -193,7 +193,7 @@ func (r *repository) Put(ctx context.Context, manifest *manifest.SignedManifest)
 
 		client, ok := UserClientFrom(ctx)
 		if !ok {
-			log.Errorf("Error creating user client to auto provision ImageStream: OpenShift user client unavailable")
+			log.Errorf("Error creating user client to auto provision ImageStream: Atomic Enterprise user client unavailable")
 			return statusErr
 		}
 

--- a/pkg/generate/app/cmd/newapp_test.go
+++ b/pkg/generate/app/cmd/newapp_test.go
@@ -470,7 +470,7 @@ func TestRunAll(t *testing.T) {
 				templateResolver: app.TemplateResolver{
 					Client: &client.Fake{},
 					TemplateConfigsNamespacer: &client.Fake{},
-					Namespaces:                []string{"openshift", "default"},
+					Namespaces:                []string{"atomicenterprise", "default"},
 				},
 				detector: app.SourceRepositoryEnumerator{
 					Detectors: source.DefaultDetectors,

--- a/pkg/generate/app/errors.go
+++ b/pkg/generate/app/errors.go
@@ -50,7 +50,7 @@ func (e ErrMultipleMatches) UsageError(commandName string) string {
 		fmt.Fprintf(buf, "  Use %[1]s to specify this image or template\n\n", match.Argument)
 	}
 	return fmt.Sprintf(`
-The argument %[1]q could apply to the following Docker images or OpenShift image repositories:
+The argument %[1]q could apply to the following Docker images or Atomic Enterprise image repositories:
 
 %[2]s
 `, e.Image, buf.String())

--- a/plugins/osdn/osdn.go
+++ b/plugins/osdn/osdn.go
@@ -29,7 +29,7 @@ type OsdnRegistryInterface struct {
 }
 
 func NetworkPluginName() string {
-	return "redhat/openshift-ovs-subnet"
+	return "redhat/atomic-enterprise-ovs-subnet"
 }
 
 func Master(osClient *osclient.Client, kClient *kclient.Client, clusterNetwork string, clusterNetworkLength uint) {

--- a/plugins/route/allocation/simple/plugin.go
+++ b/plugins/route/allocation/simple/plugin.go
@@ -11,8 +11,7 @@ import (
 )
 
 // Default DNS suffix to use if no configuration is passed to this plugin.
-// Would be better if we could use "v3.openshift.app", someone bought that!
-const defaultDNSSuffix = "v3.openshift.com"
+const defaultDNSSuffix = "ae.projectatomic.io"
 
 // SimpleAllocationPlugin implements the route.AllocationPlugin interface
 // to provide a simple unsharded (or single sharded) allocation plugin.

--- a/plugins/route/allocation/simple/plugin_test.go
+++ b/plugins/route/allocation/simple/plugin_test.go
@@ -32,7 +32,7 @@ func TestNewSimpleAllocationPlugin(t *testing.T) {
 			ErrorExpectation: true,
 		},
 		{
-			Name:             "こんにちはopenshift.com",
+			Name:             "こんにちはprojectatomic.io",
 			ErrorExpectation: true,
 		},
 		{

--- a/plugins/router/template/plugin.go
+++ b/plugins/router/template/plugin.go
@@ -151,7 +151,7 @@ func peerEndpointsKey(namespacedName ktypes.NamespacedName) string {
 	return fmt.Sprintf("%s/%s", namespacedName.Namespace, namespacedName.Name)
 }
 
-// createRouterEndpoints creates openshift router endpoints based on k8s endpoints
+// createRouterEndpoints creates atomic-enterprise router endpoints based on k8s endpoints
 func createRouterEndpoints(endpoints *kapi.Endpoints) []Endpoint {
 	out := make([]Endpoint, 0, len(endpoints.Subsets)*4)
 

--- a/tuned/man/tuned-profiles-atomic-enterprise-node.7
+++ b/tuned/man/tuned-profiles-atomic-enterprise-node.7
@@ -1,0 +1,59 @@
+.\"/* 
+.\" * All rights reserved
+.\" * Copyright (C) 2015 Red Hat, Inc.
+.\" * Authors: Jaroslav Škarvada, Scott Dodson
+.\" *
+.\" * This program is free software; you can redistribute it and/or
+.\" * modify it under the terms of the GNU General Public License
+.\" * as published by the Free Software Foundation; either version 2
+.\" * of the License, or (at your option) any later version.
+.\" *
+.\" * This program is distributed in the hope that it will be useful,
+.\" * but WITHOUT ANY WARRANTY; without even the implied warranty of
+.\" * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+.\" * GNU General Public License for more details.
+.\" *
+.\" * You should have received a copy of the GNU General Public License
+.\" * along with this program; if not, write to the Free Software
+.\" * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+.\" */
+.\" 
+.TH TUNED_PROFILES_ATOMIC_ENTERPRISE_NODE "7" "12 Feb 2015" "Atomic Enterprise" "tuned"
+.SH NAME
+tuned\-profiles\-atomic-enterprise-node - description of profiles provided for Atomic Enterprise
+
+.SH DESCRIPTION
+These profiles are provided for Atomic Enterprise nodes. They provide performance
+optimizations for Atomic Enterprise Nodes running on either bare metal
+(atomic-enterprise-node-host) or virtual machines (atomic-enterprise-node-guest).
+
+.SH PROFILES
+The following profiles are provided:
+
+.TP
+.BI "atomic-enterprise-node\-host"
+Profile optimized for Atomic Enterprise hosts (bare metal). It is based on throughput\-performance
+profile. It additionally increases SELinux AVC cache, PID limit and tunes
+netfilter connections tracking.
+
+.TP
+.BI "atomic-enterprise-node\-guest"
+Profile optimized for virtual Atomic Enterprise guests. It is based on virtual\-guest
+profile. It additionally increases SELinux AVC cache, PID limit and tunes
+netfilter connections tracking.
+
+.SH "FILES"
+.NF
+.I /etc/tuned/*
+.I /usr/lib/tuned/*
+
+.SH "SEE ALSO"
+.BR tuned (8)
+.BR tuned\-adm (8)
+.BR tuned\-profiles (7)
+.BR tuned\-profiles\-sap (7)
+.BR tuned\-profiles\-sap\-hana (7)
+.BR tuned\-profiles\-compat (7)
+.SH AUTHOR
+.NF
+Scott Dodson <sdodson@redhat.com>


### PR DESCRIPTION
- Renamed openshift* binaries to atomic-enterprise*
- Error messages that are not OpenShift specific now reference Atomic Enterprise
- CLI flags descriptions updated

Verification:
- unittests all passed
- cmd tests do not pass, but failed at the same point before this PR (will open an issue)
- RPM packages all build and lint as they did before